### PR TITLE
Make code Python 2 compatible

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,4 +1,5 @@
-An basis-set curve-fitting optimization package.
+FittingBasisSets is a basis-set curve-fitting optimization package.
+
 Copyright (C) 2018 The FittingBasisSets Development Team.
 
 This file is part of FittingBasisSets.
@@ -15,3 +16,4 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, see <http://www.gnu.org/licenses/>
+

--- a/fit_densities.py
+++ b/fit_densities.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/__init__.py
+++ b/fitting/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/greedy/__init__.py
+++ b/fitting/greedy/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/greedy/greedy_kl.py
+++ b/fitting/greedy/greedy_kl.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/greedy/greedy_lq.py
+++ b/fitting/greedy/greedy_lq.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/greedy/greedy_strat.py
+++ b/fitting/greedy/greedy_strat.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/greedy/greedy_utils.py
+++ b/fitting/greedy/greedy_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/greedy/test/test_greedy_kl.py
+++ b/fitting/greedy/test/test_greedy_kl.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
+# Copyright (C) 2018 The FittingBasisSets Development Team.
+#
+# This file is part of FittingBasisSets.
+#
+# FittingBasisSets is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# FittingBasisSets is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# ---
 r"""
 
 """

--- a/fitting/greedy/test/test_greedy_utils.py
+++ b/fitting/greedy/test/test_greedy_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/kl_divergence/__init__.py
+++ b/fitting/kl_divergence/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/kl_divergence/gaussian_kl.py
+++ b/fitting/kl_divergence/gaussian_kl.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/kl_divergence/kull_leib_fitting.py
+++ b/fitting/kl_divergence/kull_leib_fitting.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/kl_divergence/molecular_fitting.py
+++ b/fitting/kl_divergence/molecular_fitting.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# A basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/kl_divergence/test/test_gaussian_kl.py
+++ b/fitting/kl_divergence/test/test_gaussian_kl.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/kl_divergence/test/test_kull_leib_fitting.py
+++ b/fitting/kl_divergence/test/test_kull_leib_fitting.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/kl_divergence/test/test_molecular_fitting.py
+++ b/fitting/kl_divergence/test/test_molecular_fitting.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# A basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/kl_divergence/test/test_valence_kl.py
+++ b/fitting/kl_divergence/test/test_valence_kl.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/kl_divergence/valence_kl.py
+++ b/fitting/kl_divergence/valence_kl.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/__init__.py
+++ b/fitting/least_squares/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/density_model.py
+++ b/fitting/least_squares/density_model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/gaussian_density/__init__.py
+++ b/fitting/least_squares/gaussian_density/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/gaussian_density/gaussian_dens.py
+++ b/fitting/least_squares/gaussian_density/gaussian_dens.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/gaussian_density/test/test_gaussianbasisset.py
+++ b/fitting/least_squares/gaussian_density/test/test_gaussianbasisset.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/least_sqs.py
+++ b/fitting/least_squares/least_sqs.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/slater_density/__init__.py
+++ b/fitting/least_squares/slater_density/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/slater_density/atomic_slater_density.py
+++ b/fitting/least_squares/slater_density/atomic_slater_density.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/slater_density/atomic_slater_wfn.py
+++ b/fitting/least_squares/slater_density/atomic_slater_wfn.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/slater_density/test/test_atomic_slater_density.py
+++ b/fitting/least_squares/slater_density/test/test_atomic_slater_density.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/slater_density/test/test_atomic_slater_wfn.py
+++ b/fitting/least_squares/slater_density/test/test_atomic_slater_wfn.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/least_squares/test/test_density_model.py
+++ b/fitting/least_squares/test/test_density_model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/radial_grid/__init__.py
+++ b/fitting/radial_grid/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/radial_grid/clenshaw_curtis.py
+++ b/fitting/radial_grid/clenshaw_curtis.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/radial_grid/cubic_grid.py
+++ b/fitting/radial_grid/cubic_grid.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# A basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/radial_grid/general_grid.py
+++ b/fitting/radial_grid/general_grid.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/radial_grid/test/test_clenshaw_curtis.py
+++ b/fitting/radial_grid/test/test_clenshaw_curtis.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/radial_grid/test/test_cubic_grid.py
+++ b/fitting/radial_grid/test/test_cubic_grid.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/radial_grid/test/test_general_grid.py
+++ b/fitting/radial_grid/test/test_general_grid.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# An basis-set curve-fitting optimization package.
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
 # Copyright (C) 2018 The FittingBasisSets Development Team.
 #
 # This file is part of FittingBasisSets.

--- a/fitting/utils/__init__.py
+++ b/fitting/utils/__init__.py
@@ -1,1 +1,22 @@
+# -*- coding: utf-8 -*-
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
+# Copyright (C) 2018 The FittingBasisSets Development Team.
+#
+# This file is part of FittingBasisSets.
+#
+# FittingBasisSets is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# FittingBasisSets is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# ---
 from fitting.utils import plotting_utils

--- a/fitting/utils/plotting_utils.py
+++ b/fitting/utils/plotting_utils.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
+# Copyright (C) 2018 The FittingBasisSets Development Team.
+#
+# This file is part of FittingBasisSets.
+#
+# FittingBasisSets is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# FittingBasisSets is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# ---
 r"""Contain plotting utility functions for fit_densities file."""
 
 import matplotlib.pyplot as plt

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,24 @@
+# -*- coding: utf-8 -*-
+# FittingBasisSets is a basis-set curve-fitting optimization package.
+#
+# Copyright (C) 2018 The FittingBasisSets Development Team.
+#
+# This file is part of FittingBasisSets.
+#
+# FittingBasisSets is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# FittingBasisSets is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# ---
 from setuptools import setup, find_packages
 
 setup(


### PR DESCRIPTION
To make the code compatible with Python 2 (so that it can be easily used with HORTON, in case someone wants to use them at the same time), we need to decide on how to deal with abstract classes. Based on my understanding:

* In Python 2, you cannot instantiate abstract classes directly, like `KullbackLeiblerFitting`, so they cannot be tested directly (as is done right now).

* In Python 2, abstract classes cannot have abstract methods whose name starts with an underscore. So, running tests, you get error messages like:

```
File "/Users/Farnaz/projects/fitting/fitting/kl_divergence/test/test_valence_kl.py", line 54, in test_get_norm_constant
    kl = GaussianValKL(g, 3. * np.exp(-5 * g.radii**2.), 5., 1)
TypeError: Can't instantiate abstract class GaussianValKL with abstract methods _get_deriv_coeffs, _get_deriv_fparams
```

We should either make necessary changes to avoid these errors OR make the base classes non-abstract for now. I made this pull request following the later, as these classes seem to be more of a base class than a template. Feel free to let me know what you think and any other alternative.

