### PR TITLE
Refactor measure.py

### DIFF
--- a/bfit/fit.py
+++ b/bfit/fit.py
@@ -90,7 +90,9 @@ import warnings
 from scipy.optimize import minimize, NonlinearConstraint
 from timeit import default_timer as timer
 
-from bfit.measure import KLDivergence, SquaredDifference
+from bfit.measure import (
+    KLDivergence, Measure, SquaredDifference, TsallisDivergence
+)
 
 
 __all__ = ["KLDivergenceSCF", "GaussianBasisFit"]
@@ -108,8 +110,9 @@ class _BaseFit(object):
         The true function evaluated on the grid points from `grid`.
     model : (AtomicGaussianDensity, MolecularGaussianDensity)
         The Gaussian basis model density. Located in `model.py`.
-    measure : (SquaredDifference, KLDivergence)
-        The deviation measure between true density and model density. Located in `measure.py`
+    measure : Measure
+        The deviation measure between true density and model density.
+        See bfit.measure.py for examples of measures to use.
 
     Methods
     -------

--- a/bfit/fit.py
+++ b/bfit/fit.py
@@ -386,8 +386,10 @@ class KLDivergenceSCF(_BaseFit):
         -------
         result : dict
             The optimization results presented as a dictionary containing:
-            "x" : (ndarray, ndarray)
-                The optimized coefficients and exponents.
+            "coeffs" : ndarray
+                The optimized coefficients of Gaussian model.
+            "exps" : ndarray
+                The optimized exponents of Gaussian model.
             "success": bool
                 Whether or not the optimization exited successfully.
             "fun" : ndarray
@@ -456,7 +458,8 @@ class KLDivergenceSCF(_BaseFit):
         else:
             success = True
 
-        results = {"x": (new_cs, new_es),
+        results = {"coeffs": new_cs,
+                   "exps" : new_es,
                    "fun": np.array(fun),
                    "success": success,
                    "performance": np.array(performance),
@@ -612,8 +615,10 @@ class GaussianBasisFit(_BaseFit):
         -------
         result : dict
             The optimization results presented as a dictionary containing:
-            "x" : (ndarray, ndarray)
-                The optimized coefficients and exponents, respectively.
+            "coeffs" : ndarray
+                The optimized coefficients of Gaussian model.
+            "exps" : ndarray
+                The optimized exponents of Gaussian model.
             "success": bool
                 Whether or not the optimization exited successfully.
             "message" : str
@@ -700,7 +705,8 @@ class GaussianBasisFit(_BaseFit):
         else:
             coeffs, expons = c0, res["x"]
 
-        results = {"x": (coeffs, expons),
+        results = {"coeffs": coeffs,
+                   "exps" : expons,
                    "fun": res["fun"],
                    "success": res["success"],
                    "message": res["message"],

--- a/bfit/fit.py
+++ b/bfit/fit.py
@@ -188,7 +188,7 @@ class _BaseFit(object):
         # evaluate approximate model density
         approx = self.model.evaluate(coeffs, expons)
         # compute deviation measure on the grid
-        value = self.measure.evaluate(approx, deriv=False)
+        value = self.measure.evaluate(self.density, approx, deriv=False)
         diff = np.abs(self.density - approx)
         return [self.grid.integrate(approx),
                 self.grid.integrate(diff),
@@ -292,7 +292,7 @@ class KLDivergenceSCF(_BaseFit):
 
         """
         # initialize KL deviation measure
-        measure = KLDivergence(density, mask_value=mask_value)
+        measure = KLDivergence(mask_value=mask_value)
         super(KLDivergenceSCF, self).__init__(grid, density, model, measure, integral_dens)
         # compute lagrange multiplier
         self._lm = self.grid.integrate(self.density) / self.integral_dens
@@ -332,7 +332,7 @@ class KLDivergenceSCF(_BaseFit):
         # compute model density & its derivative
         m, dm = self.model.evaluate(coeffs, expons, deriv=True)
         # compute KL divergence & its derivative
-        k, dk = self.measure.evaluate(m, deriv=True)
+        k, dk = self.measure.evaluate(self.density, m, deriv=True)
         # compute averages needed to update parameters
         avrg1, avrg2 = np.zeros(self.model.nbasis), np.zeros(self.model.nbasis)
         for index in range(self.model.nbasis):
@@ -735,7 +735,7 @@ class GaussianBasisFit(_BaseFit):
         # compute linear combination of gaussian basis functions
         m, dm = self.evaluate_model(x, *args)
         # compute KL divergence
-        k, dk = self.measure.evaluate(m, deriv=True)
+        k, dk = self.measure.evaluate(self.density, m, deriv=True)
         # compute objective function & its derivative
         obj = self.grid.integrate(self.weights * k)
         d_obj = np.zeros_like(x)

--- a/bfit/measure.py
+++ b/bfit/measure.py
@@ -20,17 +20,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # ---
-"""
-Deviation Measure Module.
-
-Classes that measure the deviation between true and model probability distributions.
-
-Classes
--------
-    KLDivergence - Kullback-Leibler divergence measure.
-    SquaredDifference - Square-Difference measure for Least-Squared method.
-
-"""
+"""Measure Module."""
 
 
 import numpy as np

--- a/bfit/measure.py
+++ b/bfit/measure.py
@@ -27,7 +27,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 
-__all__ = ["KLDivergence", "SquaredDifference"]
+__all__ = ["SquaredDifference", "KLDivergence", "TsallisDivergence"]
 
 
 class Measure(ABC):
@@ -202,3 +202,103 @@ class KLDivergence(Measure):
         if deriv:
             return value, -ratio
         return value
+
+
+class TsallisDivergence(Measure):
+    r"""Tsallis Divergence Class"""
+    def __init__(self, alpha=1.001, mask_value=1.e-12):
+        r"""
+        Construct the Kullback-Leibler class.
+
+        Parameters
+        ----------
+        alpha : float
+            The alpha parameter of the Tsallis divergence. If it tends towards
+            one, then Tsallis divergence approaches Kullback-Leibler.
+        mask_value : float, optional
+            The elements less than or equal to this number are masked in a division,
+            and then replaced with the value of one so that logarithm of one is zero.
+        """
+        self._alpha = alpha
+        self._mask_value = mask_value
+        if self._alpha < 0:
+            raise ValueError(f"Alpha parameter {alpha} should be positive.")
+        if np.abs(self._alpha - 1.0) < 1e-10:
+            raise ValueError(f"Alpha parameter {alpha} shouldn't be equal to one."
+                             f"Use Kullback-Leibler divergence instead.")
+        super(TsallisDivergence, self).__init__()
+
+    @property
+    def alpha(self):
+        r"""Alpha parameter of the Tsallis divergence."""
+        return self._alpha
+
+    @property
+    def mask_value(self):
+        r"""Masking value used when evaluating the measure."""
+        return self._mask_value
+
+    def evaluate(self, density, model, deriv=False):
+        r"""
+        The integrand of Tsallis divergence:
+
+        .. math::
+            \int_G \frac{1}{\alpha - 1} f(x) \bigg(\frac{f(x)}{g(x)}^{q- 1} - 1\bigg) dx,
+        where
+            :math:`f` is the true probability distribution,
+            :math:`g` is the model probability distribution.
+            :math:`G` is the grid being integrated on.
+
+        Parameters
+        ----------
+        density : ndarray(N,)
+            The exact density evaluated on the grid points.
+        model : ndarray(N,)
+            The model density evaluated on the grid points.
+        deriv : bool, optional
+            Whether to compute the derivative of squared difference w.r.t. model density.
+
+        Returns
+        -------
+        m : ndarray(N,)
+            The Tsallis divergence between density & model on the grid points.
+        dm : ndarray(N,)
+            The derivative of divergence w.r.t. model density evaluated on the grid points.
+            Only returned if `deriv=True`.
+
+        Notes
+        -----
+        - This does not impose non-negativity of the model density, unlike the Kullback-Leibler.
+        - Values of Model density that are less than `mask_value` are masked when used in
+            division and then replaced with the value of 0.
+        - As :math:`\alpha` parameter tends towards one, then this converges to the Kullback-Leibler.
+            This is particularly useful for trust-region methods that don't impose strict constraints
+            during the optimization procedure.
+
+        References
+        ----------
+        [1] Ayers, Paul W. "Information theory, the shape function, and the Hirshfeld atom."
+            Theoretical Chemistry Accounts 115.5 (2006): 370-378.
+        [2] Heidar-Zadeh, Farnaz, Ivan Vinogradov, and Paul W. Ayers. "Hirshfeld partitioning
+            from non-extensive entropies." Theoretical Chemistry Accounts 136.4 (2017): 54.
+
+        """
+        # check model density
+        if not isinstance(model, np.ndarray):
+            raise ValueError("Argument model should be {0} array.".format(density.shape))
+        if not isinstance(density, np.ndarray) or density.ndim != 1:
+            raise ValueError("Arguments density should be a 1D numpy array.")
+        if model.shape != density.shape:
+            raise ValueError(f"Model shape {model.shape} should be the same as density"
+                             f" {density.shape}.")
+        if not isinstance(deriv, bool):
+            raise TypeError(f"Deriv {type(deriv)} should be Boolean type.")
+
+        # compute ratio & replace masked values by 1.0
+        ratio = density / np.ma.masked_less_equal(model, self.mask_value)
+        ratio = np.ma.filled(ratio, fill_value=0.0)
+        value = density * (np.power(ratio, self.alpha - 1.0) - 1.0)
+        integrand = value / (self.alpha - 1.0)
+        if deriv:
+            return integrand, -np.power(ratio, self.alpha)
+        return integrand

--- a/bfit/test/test_measure.py
+++ b/bfit/test/test_measure.py
@@ -29,84 +29,90 @@ from bfit.measure import KLDivergence, SquaredDifference
 
 
 def test_raises_kl():
+    r"""Test raise error when using Kullback-Leibler."""
+    measure = KLDivergence()
     # check density argument
-    assert_raises(ValueError, KLDivergence, 3.5)
-    assert_raises(ValueError, KLDivergence, np.array([[1., 2., 3.]]))
-    assert_raises(ValueError, KLDivergence, np.array([[1.], [2.], [3.]]))
-    assert_raises(ValueError, KLDivergence, np.array([-1., 2., 3.]))
-    assert_raises(ValueError, KLDivergence, np.array([1., -2., -3.]))
+    assert_raises(ValueError, measure.evaluate, 3.5, np.ones((10,)))
+    assert_raises(ValueError, measure.evaluate, np.array([[1., 2., 3.]]), np.ones((10,)))
+    assert_raises(ValueError, measure.evaluate, np.array([[1.], [2.], [3.]]), np.ones((10,)))
+    assert_raises(ValueError, measure.evaluate, np.array([-1., 2., 3.]), np.ones((10,)))
+    assert_raises(ValueError, measure.evaluate, np.array([1., -2., -3.]), np.ones((10,)))
     # check model argument
-    measure = KLDivergence(np.array([1., 2., 3.]))
-    assert_raises(ValueError, measure.evaluate, 1.75)
-    assert_raises(ValueError, measure.evaluate, np.array([1., 2., 3., 4.]))
-    assert_raises(ValueError, measure.evaluate, np.array([[1.], [2.], [3.]]))
-    assert_raises(ValueError, measure.evaluate, np.array([1., 2., -3.]))
-    assert_raises(ValueError, measure.evaluate, np.array([-0.5, -1.3, -2.8]))
+    assert_raises(ValueError, measure.evaluate, np.array([1., 2., 3.]), 1.75)
+    assert_raises(ValueError, measure.evaluate, np.array([1., 2., 3.]), np.array([1., 2., 3., 4.]))
+    assert_raises(ValueError, measure.evaluate, np.array([1., 2., 3.]), np.array([[1.], [2.], [3.]]))
+    assert_raises(ValueError, measure.evaluate, np.array([1., 2., 3.]), np.array([1., 2., -3.]))
+    assert_raises(ValueError, measure.evaluate, np.array([1., 2., 3.]), np.array([-0.5, -1.3, -2.8]))
 
 
 def test_evaluate_kl_equal():
+    r"""Test evaluating Kullback-Leibler and its derivative against zero model."""
     # test equal density & zero model
     dens = np.array([0.0, 1.0, 2.0])
     model = np.array([0., 0., 0.])
-    measure = KLDivergence(dens, mask_value=1.e-12)
-    assert_almost_equal(np.array([0., 0., 0.]), measure.evaluate(dens, deriv=False), decimal=8)
-    assert_almost_equal(np.array([0., 0., 0.]), measure.evaluate(dens, deriv=True)[0], decimal=8)
-    assert_almost_equal(-np.array([1., 1., 1.]), measure.evaluate(dens, deriv=True)[1], decimal=8)
-    assert_almost_equal(np.array([0., 0., 0.]), measure.evaluate(model, deriv=False), decimal=8)
-    assert_almost_equal(np.array([0., 0., 0.]), measure.evaluate(model, deriv=True)[0], decimal=8)
-    assert_almost_equal(-np.array([1., 1., 1.]), measure.evaluate(model, deriv=True)[1], decimal=8)
+    measure = KLDivergence(mask_value=1.e-12)
+    assert_almost_equal(np.array([0., 0., 0.]), measure.evaluate(dens, dens, deriv=False), decimal=8)
+    assert_almost_equal(np.array([0., 0., 0.]), measure.evaluate(dens, dens, deriv=True)[0], decimal=8)
+    assert_almost_equal(-np.array([1., 1., 1.]), measure.evaluate(dens, dens, deriv=True)[1], decimal=8)
+    assert_almost_equal(np.array([0., 0., 0.]), measure.evaluate(dens, model, deriv=False), decimal=8)
+    assert_almost_equal(np.array([0., 0., 0.]), measure.evaluate(dens, model, deriv=True)[0], decimal=8)
+    assert_almost_equal(-np.array([1., 1., 1.]), measure.evaluate(dens, model, deriv=True)[1], decimal=8)
 
 
 def test_evaluate_kl():
+    r"""Test evaluating Kullback-Leibler and its derivative against sympy results."""
     # test different density and model against sympy
     dens = np.linspace(0.0, 10., 15)
     model = np.linspace(0.0, 12., 15)
     # KL divergence measure
-    measure = KLDivergence(dens, mask_value=1.e-12)
+    measure = KLDivergence(mask_value=1.e-12)
     k = np.array([0., -0.1302296834, -0.2604593668, -0.3906890503, -0.5209187337, -0.6511484171,
                   -0.7813781005, -0.911607784, -1.0418374674, -1.1720671508, -1.3022968342,
                   -1.4325265177, -1.5627562011, -1.6929858845, -1.8232155679])
     dk = np.array([-1.0] + [-0.8333333333] * 14)
-    assert_almost_equal(k, measure.evaluate(model, deriv=False), decimal=8)
-    assert_almost_equal(k, measure.evaluate(model, deriv=True)[0], decimal=8)
-    assert_almost_equal(dk, measure.evaluate(model, deriv=True)[1], decimal=8)
+    assert_almost_equal(k, measure.evaluate(dens, model, deriv=False), decimal=8)
+    assert_almost_equal(k, measure.evaluate(dens, model, deriv=True)[0], decimal=8)
+    assert_almost_equal(dk, measure.evaluate(dens, model, deriv=True)[1], decimal=8)
 
 
 def test_raises_squared_difference():
+    r"""Test raises error in squared difference class."""
+    ls = SquaredDifference()
     # check density argument
-    assert_raises(ValueError, SquaredDifference, 3.5)
-    assert_raises(ValueError, SquaredDifference, np.array([[1., 2., 3.]]))
-    assert_raises(ValueError, SquaredDifference, np.array([[1.], [2.], [3.]]))
+    assert_raises(ValueError, ls.evaluate, 3.5, np.ones((10,)))
+    assert_raises(ValueError, ls.evaluate, np.array([[1., 2., 3.]]), np.ones((10,)))
+    assert_raises(ValueError, ls.evaluate, np.array([[1.], [2.], [3.]]), np.ones((10,)))
     # check model argument
-    measure = SquaredDifference(np.array([1., 2., 3.]))
-    assert_raises(ValueError, measure.evaluate, 1.75)
-    assert_raises(ValueError, measure.evaluate, np.array([1., 2., 3., 4.]))
-    assert_raises(ValueError, measure.evaluate, np.array([[1.], [2.], [3.]]))
+    assert_raises(ValueError, ls.evaluate, np.array([1., 2., 3.]), 1.75)
+    assert_raises(ValueError, ls.evaluate, np.array([1., 2., 3.]), np.array([1., 2., 3., 4.]))
+    assert_raises(ValueError, ls.evaluate, np.array([1., 2., 3.]), np.array([[1.], [2.], [3.]]))
 
 
 def test_evaluate_squared_difference_equal():
+    r"""Test evaluating square difference on a zero model."""
     # test equal density & zero model
     dens = np.array([0.0, 1.0, 2.0])
     model = np.array([0., 0., 0.])
-    measure = SquaredDifference(dens)
-    assert_almost_equal(np.zeros(3), measure.evaluate(dens, deriv=False), decimal=8)
-    assert_almost_equal(np.zeros(3), measure.evaluate(dens, deriv=True)[0], decimal=8)
-    assert_almost_equal(np.zeros(3), measure.evaluate(dens, deriv=True)[1], decimal=8)
-    assert_almost_equal(dens**2, measure.evaluate(model, deriv=False), decimal=8)
-    assert_almost_equal(dens**2, measure.evaluate(model, deriv=True)[0], decimal=8)
-    assert_almost_equal(-2 * dens, measure.evaluate(model, deriv=True)[1], decimal=8)
+    measure = SquaredDifference()
+    assert_almost_equal(np.zeros(3), measure.evaluate(dens, dens, deriv=False), decimal=8)
+    assert_almost_equal(np.zeros(3), measure.evaluate(dens, dens, deriv=True)[0], decimal=8)
+    assert_almost_equal(np.zeros(3), measure.evaluate(dens, dens, deriv=True)[1], decimal=8)
+    assert_almost_equal(dens**2, measure.evaluate(dens, model, deriv=False), decimal=8)
+    assert_almost_equal(dens**2, measure.evaluate(dens, model, deriv=True)[0], decimal=8)
+    assert_almost_equal(-2 * dens, measure.evaluate(dens, model, deriv=True)[1], decimal=8)
 
 
 def test_evaluate_squared_difference():
+    r"""Test evaluating the squared difference and its derivative against sympy."""
     # test different density and model against sympy
     dens = np.linspace(0.0, 10., 15)
     model = np.linspace(0.0, 12., 15)
     # KL divergence measure
-    measure = SquaredDifference(dens)
+    measure = SquaredDifference()
     # equal density
-    assert_almost_equal(np.zeros(15), measure.evaluate(dens, deriv=False), decimal=8)
-    assert_almost_equal(np.zeros(15), measure.evaluate(dens, deriv=True)[0], decimal=8)
-    assert_almost_equal(np.zeros(15), measure.evaluate(dens, deriv=True)[1], decimal=8)
+    assert_almost_equal(np.zeros(15), measure.evaluate(dens, dens, deriv=False), decimal=8)
+    assert_almost_equal(np.zeros(15), measure.evaluate(dens, dens, deriv=True)[0], decimal=8)
+    assert_almost_equal(np.zeros(15), measure.evaluate(dens, dens, deriv=True)[1], decimal=8)
     # different densities
     m = np.array([0.0, 0.0204081633, 0.0816326531, 0.1836734694, 0.3265306122,
                   0.5102040816, 0.7346938776, 1.0, 1.306122449, 1.6530612245,


### PR DESCRIPTION
Measure.py contains two classes, "Squared Difference" and "KLDivergence", these two contain a single function called "evaluate"  which returns the integrand of the two functions (to get the objective function will need to integrate it) and to construct the object, one needs to add `density` to the initializor.  

Originally, we planned on turning these into functions, but I decided to not do that because I would have to change the fitting algorithms in `./bfit/fit.py` to account for each type of measure.

I have changed the following:
- Removed `density` argument to the initializor of both classes, instead the evaluate function needs to give both density and model arguments.
- Made an abstract base class "Measure" that all measures need to be a subclass of.  It contains an abstract method called "evaluate".
- I added the Tsallis measure as well and added tests for it. One test is brute-force and the others are how well it gets to the Kullback-Leibler as alpha approaches one.
- I added an option in fit.py to include the analytic integral of the density function rather than using the numerical integral.
- In the fitting algorithms in fit.py, rather than returning res["x"], that includes both coefficients and exponents, this would return res["coeffs"] and res["exps"].
