### PR TITLE
Add error if grid object is not correct

### DIFF
--- a/bfit/fit.py
+++ b/bfit/fit.py
@@ -57,6 +57,10 @@ class _BaseFit:
         if np.any(density < 0.):
             raise ValueError("Density should be positive.")
         self._grid = grid
+        if not (hasattr(self.grid, "points")):
+            raise AttributeError(f"Grid class {type(self.grid)} should contain attribute 'points'.")
+        if not (hasattr(self.grid, 'integrate') and callable(getattr(self.grid, 'integrate'))):
+            raise AttributeError(f"Grid class {type(self.grid)} should contain method called 'integrate'.")
         self._density = density
         self._model = model
         self._measure = measure

--- a/bfit/test/test_fit.py
+++ b/bfit/test/test_fit.py
@@ -71,6 +71,18 @@ def test_assertion_raises():
     assert_raises(ValueError, gb.run, [], [], False, False)
     assert_raises(ValueError, gb.evaluate_model, [], ("not fixed", 2))
 
+    # Test giving a grid class with no points returns error
+    class GridNoPoints:
+        def integrate(self):
+            pass
+    assert_raises(AttributeError, ScipyFit, GridNoPoints(), e, KLDivergence())
+
+    # Test giving grid class with no integrate method returns error.
+    class GridNoIntegrate:
+        def __init__(self):
+            self.points = g.points
+    assert_raises(AttributeError, ScipyFit, GridNoIntegrate(), e, KLDivergence())
+
 
 def test_run_normalized_1s_gaussian():
     # density is normalized 1s orbital with exponent=1.0


### PR DESCRIPTION
Gives error if grid object doesn't contain grid points or integrate method.