### PR TITLE
Print the errors in a nice tabular format.

### DIFF
--- a/bfit/fit.py
+++ b/bfit/fit.py
@@ -353,9 +353,7 @@ class KLDivergenceSCF(_BaseFit):
 
             if disp:
                 print(template_iters.format(
-                     niter, performance[-1][0], performance[-1][1], performance[-1][2],
-                     performance[-1][3], performance[-1][4], max_diff_coeffs, max_diff_expons,
-                    diff_divergence)
+                     niter, *performance[-1], max_diff_coeffs, max_diff_expons, diff_divergence)
                 )
 
 
@@ -565,10 +563,7 @@ class ScipyFit(_BaseFit):
                         performance = self.goodness_of_fit(xk, e0)
                     elif opt_expons:
                         performance = self.goodness_of_fit(c0, xk)
-                    print(template_iters.format(
-                        performance[0], performance[1], performance[2],
-                        performance[3], performance[4])
-                    )
+                    print(template_iters.format(*performance))
 
                 callback = print_results
             elif self.method == "trust-constr":
@@ -585,10 +580,7 @@ class ScipyFit(_BaseFit):
                         performance = self.goodness_of_fit(xk, e0)
                     elif opt_expons:
                         performance = self.goodness_of_fit(c0, xk)
-                    print(template_iters.format(
-                        performance[0], performance[1], performance[2],
-                        performance[3], performance[4])
-                    )
+                    print(template_iters.format(*performance))
                 callback = print_results
         # optimize
         start = timer()  # Start timer

--- a/bfit/fit.py
+++ b/bfit/fit.py
@@ -269,8 +269,7 @@ class KLDivergenceSCF(_BaseFit):
         d_threshold : float
             The termination threshold for absolute change in divergence value. Default is 1e-6.
         disp : bool
-            If true, then at each iteration the error measures, :math:`L_1`, :math:`L_\infty`
-            and Kullback-Leibler measure is printed. Default is False.
+            If true, then at each iteration various error measures will be printed.
 
         Returns
         -------
@@ -308,6 +307,24 @@ class KLDivergenceSCF(_BaseFit):
         fun, performance = [], []
         niter = 0
         start = timer()
+
+        if disp:
+            # Template for the header.
+            print("-" * (10 + 12 + 15 + 15 + 15 + 15 + 15 + 15 + 15 + 12))
+            # Format is {identifier:width}, ^ means center it, | means put a bar in it
+            template_header = (
+                "|{0:^10}|{1:^12}|{2:^15}|{3:^15}|{4:^15}|{5:^16}|{6:^15}|{7:^15}|{8:^15}|"
+            )
+            # Print the headers
+            print(template_header.format(
+                "Iteration", "Integration", "L1", "L Infinity", "Least-squares",
+                "Kullback-Leibler", "Change Coeffs", "Change Exps", "Change Objective")
+            )
+            print("-" * (10 + 12 + 15 + 15 + 15 + 15 + 15 + 15 + 15 + 12))
+            # Template for float iteration
+            template_iters = (
+                "|{0:^10d}|{1:^12f}|{2:^15e}|{3:^15f}|{4:^15e}|{5:^16e}|{6:^15e}|{7:^15e}|{8:^15e}|"
+            )
         while ((max_diff_expons > e_threshold or max_diff_coeffs > c_threshold) and
                diff_divergence > d_threshold) and maxiter > niter:
 
@@ -335,10 +352,13 @@ class KLDivergenceSCF(_BaseFit):
                 diff_divergence = np.abs(performance[niter - 1][-1] - performance[niter - 2][-1])
 
             if disp:
-                print(niter, performance[-1])
-                print(diff_divergence, max_diff_coeffs, max_diff_expons)
-                print(new_cs, new_es)
-                print("\n")
+                print(template_iters.format(
+                     niter, performance[-1][0], performance[-1][1], performance[-1][2],
+                     performance[-1][3], performance[-1][4], max_diff_coeffs, max_diff_expons,
+                    diff_divergence)
+                )
+
+
         end = timer()
         time = end - start
 
@@ -347,6 +367,13 @@ class KLDivergenceSCF(_BaseFit):
             success = False
         else:
             success = True
+
+        if disp:
+            print("-" * (10 + 12 + 15 + 15 + 15 + 15 + 15 + 15 + 15 + 12))
+            print(f"Successful?: {success}")
+            print(f"Time: {time:.2f} seconds")
+            print(f"Coefficients {new_cs}")
+            print(f"Exponents {new_es}")
 
         results = {"coeffs": new_cs,
                    "exps" : new_es,
@@ -445,7 +472,8 @@ class ScipyFit(_BaseFit):
             For slsqp. precision goal for the value of objective function in the stopping criterion.
             For trust-constr, it is precision goal for the change in independent variables.
         disp : bool
-            If True, then it will print the convergence messages from the optimizer.
+            If True, then it will print the iteration errors, convergence messages from the optimizer
+            and will print out various error measures at each iteration.
         with_constraint : bool
             If true, then adds the constraint that the integration of the model density must
             be equal to the constraint of true density. The default is True.
@@ -514,9 +542,54 @@ class ScipyFit(_BaseFit):
         callback = None
         if disp:
             if self.method == "slsqp":
-                callback = lambda xk : print(self.goodness_of_fit(xk[:len(c0)], xk[len(c0):]))
+                # Template for the header.
+                print("-" * (10 + 12 + 15 + 15 + 15 + 12))
+                # Format is {identifier:width}, ^ means center it, | means put a bar in it
+                template_header = (
+                    "|{0:^12}|{1:^15}|{2:^15}|{3:^15}|{4:^16}|"
+                )
+                # Print the headers
+                print(template_header.format(
+                    "Integration", "L1", "L Infinity", "Least-squares", "Kullback-Leibler")
+                )
+                print("-" * (10 + 12 + 15 + 15 + 15 + 12))
+                # Template for float iteration
+                template_iters = (
+                    "|{0:^12f}|{1:^15e}|{2:^15f}|{3:^15e}|{4:^16e}|"
+                )
+
+                def print_results(xk):
+                    if opt_coeffs and opt_expons:
+                        performance = self.goodness_of_fit(xk[:len(c0)], xk[len(c0):])
+                    elif opt_coeffs:
+                        performance = self.goodness_of_fit(xk, e0)
+                    elif opt_expons:
+                        performance = self.goodness_of_fit(c0, xk)
+                    print(template_iters.format(
+                        performance[0], performance[1], performance[2],
+                        performance[3], performance[4])
+                    )
+
+                callback = print_results
             elif self.method == "trust-constr":
-                callback = lambda xk, res: print(self.goodness_of_fit(xk[:len(c0)], xk[len(c0):]))
+                # Template for float iteration
+                template_iters = (
+                    "Integration: {0:10f},  L1: {1:10e},  L Infinity: {2:10f}, "
+                    "Least Squares: {3:10e},  Kullback-Liebler: {4:10e}"
+                )
+
+                def print_results(xk, _):
+                    if opt_coeffs and opt_expons:
+                        performance = self.goodness_of_fit(xk[:len(c0)], xk[len(c0):])
+                    elif opt_coeffs:
+                        performance = self.goodness_of_fit(xk, e0)
+                    elif opt_expons:
+                        performance = self.goodness_of_fit(c0, xk)
+                    print(template_iters.format(
+                        performance[0], performance[1], performance[2],
+                        performance[3], performance[4])
+                    )
+                callback = print_results
         # optimize
         start = timer()  # Start timer
         res = minimize(fun=self.func,
@@ -544,14 +617,24 @@ class ScipyFit(_BaseFit):
         else:
             coeffs, expons = c0, res["x"]
 
+        if disp:
+            # Print Final Output.
+            if self.method == "slsqp":
+                print("-" * (10 + 12 + 15 + 15 + 15 + 12))
+            print(f"Successful?: {res['success']}")
+            print(f"Time: {time:.2f} seconds")
+            print("Scipy Message: " + res["message"])
+            print(f"Coefficients {coeffs}")
+            print(f"Exponents {expons}")
+
         results = {"coeffs": coeffs,
-                   "exps" : expons,
+                   "exps": expons,
                    "fun": res["fun"],
                    "success": res["success"],
                    "message": res["message"],
                    "jacobian": res["jac"],
                    "performance": np.array(self.goodness_of_fit(coeffs, expons)),
-                   "time" : time}
+                   "time": time}
         return results
 
     def func(self, x, *args):

--- a/bfit/test/test_fit.py
+++ b/bfit/test/test_fit.py
@@ -536,14 +536,14 @@ def test_kl_fit_unnormalized_1d_molecular_dens_unnormalized_1s_1s_gaussian():
     assert_almost_equal(es0, result["exps"], decimal=4)
     assert_almost_equal(0., result["fun"], decimal=8)
     # initial coeff=1. & expon=1.
-    result = kl.run(np.array([5.45, 0.001]), es0, True, False)
-    assert_almost_equal(cs0, result["coeffs"], decimal=6)
-    assert_almost_equal(es0, result["exps"], decimal=6)
+    result = kl.run(np.array([5.45, 0.001]), es0, True, False, disp=True)
+    assert_almost_equal(cs0, result["coeffs"], decimal=5)
+    assert_almost_equal(es0, result["exps"], decimal=5)
     assert_almost_equal(0., result["fun"], decimal=8)
     # initial coeff=1. & expon=1.
     result = kl.run(cs0, np.array([5.45, 0.001]), False, True)
-    assert_almost_equal(cs0, result["coeffs"], decimal=6)
-    assert_almost_equal(es0, result["exps"], decimal=6)
+    assert_almost_equal(cs0, result["coeffs"], decimal=5)
+    assert_almost_equal(es0, result["exps"], decimal=5)
     assert_almost_equal(0., result["fun"], decimal=8)
     # fit 1s density on center 1
     measure = KLDivergence()


### PR DESCRIPTION
The error measures are now printed in a tabular format within the KL SCF method and ScipyFit methods (slsqp, trust-constr)

The following shows an example of how it prints.

```
-------------------------------------------------------------------------------
|Integration |      L1       |  L Infinity   | Least-squares |Kullback-Leibler|
-------------------------------------------------------------------------------
| 244.692678 | 1.197362e+01  |   1.010882    | 2.458808e+00  |  4.479622e-01  |
| 244.692673 | 6.789005e+00  |   0.573167    | 7.904721e-01  |  1.543859e-01  |
| 244.692680 | 4.510410e-01  |   0.038080    | 3.489049e-03  |  6.597816e-04  |
| 244.692679 | 1.946128e-02  |   0.001643    | 6.495551e-06  |  1.255752e-06  |
| 244.692679 | 4.284715e-05  |   0.000004    | 3.148686e-11  |  1.058647e-09  |
| 244.692679 | 6.252744e-05  |   0.000005    | 6.705258e-11  | -3.028632e-11  |
| 244.692679 | 2.067138e-05  |   0.000002    | 7.328463e-12  | -5.231601e-13  |
| 244.692679 | 3.645272e-05  |   0.000003    | 2.278945e-11  | -2.075756e-12  |
| 244.692679 | 2.072164e-05  |   0.000002    | 7.364143e-12  |  1.401050e-12  |
| 244.692679 | 2.072164e-05  |   0.000002    | 7.364143e-12  |  1.401050e-12  |
```